### PR TITLE
Fixed timeout

### DIFF
--- a/utils/scorch2_feature_extraction.py
+++ b/utils/scorch2_feature_extraction.py
@@ -482,7 +482,7 @@ def process_pdbid(pdbid, protein_base_path, molecule_path, des_path, num_cores=N
             results = []
             for i, future in enumerate(tqdm(futures, desc=f"Processing {pdbid} molecules", leave=False)):
                 try:
-                    result = future.get(timeout=300)  # 5-minute timeout per molecule
+                    result = future.get(timeout=5 * 60)  # 5-minute timeout per molecule
                     if not result.empty:
                         results.append(result)
                 except TimeoutError:

--- a/utils/scorch2_feature_extraction.py
+++ b/utils/scorch2_feature_extraction.py
@@ -482,7 +482,7 @@ def process_pdbid(pdbid, protein_base_path, molecule_path, des_path, num_cores=N
             results = []
             for i, future in enumerate(tqdm(futures, desc=f"Processing {pdbid} molecules", leave=False)):
                 try:
-                    result = future.get(timeout=5)  # 5-minute timeout per molecule
+                    result = future.get(timeout=300)  # 5-minute timeout per molecule
                     if not result.empty:
                         results.append(result)
                 except TimeoutError:


### PR DESCRIPTION
Working with a big complex, that would take a while to extract the features from, I noticed this timeout to be a bit short... and to be set in 5 seconds instead of the 5 minutes commented, which would be sufficient for the feature extraction.